### PR TITLE
Fix fairseq version to 0.9 (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Very deep transformers for neural machine translation <br/>
    > cd nmt_eval && bash eval_enfr.sh <model_path> <gpu> <init_path> <unperbound> <count>
 
 ## Notes and Acknowledgments
-FAIRSEQ (v0.8): https://github.com/pytorch/fairseq<br/>
+FAIRSEQ (v0.9): https://github.com/pytorch/fairseq<br/>
 
 
 ### How do I cite it?


### PR DESCRIPTION
Hello, I am a student at KAIST in Korea. 
I am studying NLP and replicating your wonderful deepNMT model.

As written in the README, when I run [run_wmt14_en_fr.sh](https://github.com/microsoft/deepnmt/blob/main/run_wmt14_en_fr.sh) with fairseq 0.8 version, the following error occurred.

```
| [en] dictionary: 10152 types
| [de] dictionary: 10152 types
| loaded 7283 examples from: /home/nmt-research/repos/fairseq/examples/translation/k_databin/iwslt14.de-en.joined_dict/valid.en-de.en
| loaded 7283 examples from: /home/nmt-research/repos/fairseq/examples/translation/k_databin/iwslt14.de-en.joined_dict/valid.en-de.de
| /home/nmt-research/repos/fairseq/examples/translation/k_databin/iwslt14.de-en.joined_dict/ valid en-de 7283 examples
    load_entry_point('fairseq', 'console_scripts', 'fairseq-train')()
  File "/home/nmt-research/repos/fairseq-0.8/fairseq_cli/train.py", line 321, in cli_main
    main(args)
  File "/home/nmt-research/repos/fairseq-0.8/fairseq_cli/train.py", line 46, in main
    task.load_dataset(valid_sub_split, combine=False, epoch=0)
  File "/home/nmt-research/repos/deepnmt/deepnmt/adv_translation_task.py", line 228, in load_dataset
    self.datasets[split] = load_langpair_dataset(
  File "/home/nmt-research/repos/deepnmt/deepnmt/adv_translation_task.py", line 96, in load_langpair_dataset
    return LanguagePairDataset(
TypeError: __init__() got an unexpected keyword argument 'align_dataset'
```

I found that the `align_dataset` argument was added from version 0.9 of fairseq, and training works normally with that version. 
https://github.com/facebookresearch/fairseq/blob/v0.9.0/fairseq/data/language_pair_dataset.py#L143-L144

So I'm suggesting a small fix in README. Thank you :)

